### PR TITLE
Use inner customMetadata object when accepting api subscription

### DIFF
--- a/daikoku/app/controllers/NotificationController.scala
+++ b/daikoku/app/controllers/NotificationController.scala
@@ -245,7 +245,7 @@ class NotificationController(
                                         ctx.tenant,
                                         ctx.user,
                                         notification.sender,
-                                        ctx.request.body.asOpt[JsObject]))
+                                        ctx.request.body.asOpt[JsObject].flatMap(o => (o \ "customMetadata").asOpt[JsObject])))
               case TeamInvitation(_, user) if user != ctx.user.id =>
                 EitherT.leftT[Future, Unit](ForbiddenAction)
               case TeamInvitation(team, user) =>


### PR DESCRIPTION
When accepting an api subscription with custom metadata, the request fails because the `customMedata` object is not read, only the root object of the payload. In this PR, we only use `customMetadata` sub-object for actual `customMetadata` of the subscription
