### PR TITLE
Add Daikoku dev guide in the documentation

### DIFF
--- a/manual/docs/03-guides/16-dev.mdx
+++ b/manual/docs/03-guides/16-dev.mdx
@@ -1,0 +1,199 @@
+---
+id: develop-daikoku
+title: Daikoku Development Guide
+sidebar_position: 10
+description: How to set up a local development environment for Daikoku (frontend + backend) quickly.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Daikoku Development Guide
+
+This guide aims at helping people willing to contribute to the Daikoku codebase.
+This guide will help you set up a **full Daikoku development environment** — including PostgreSQL (via Docker), the **frontend (Vite)**, and the **backend (Scala + Play)** — with live reload enabled.
+
+> Replace or export `$DAIKOKU_PROJECT_ROOT` with your local daikoku project path, for example `~/projects/daikoku` in case you did something 
+like `git clone git@github.com:MAIF/daikoku.git ~/projects/daikoku`
+
+---
+
+## 1) Prerequisites
+
+Make sure you have the following installed:
+
+- **JDK 21+**
+- **Scala** & **sbt** (latest recommended version)
+- **Node.js 22.x** & **npm** (Vite requires a modern Node version)
+- **Docker** (to run PostgreSQL, and later Elasticsearch, Otoroshi and Minio)
+- a clone of the **Daikoku code repository** (`git clone git@github.com:MAIF/daikoku.git`)
+
+:::tip
+If you use **nvm**, you can install Node 22 easily:
+```bash
+nvm install 22
+nvm use 22
+node -v   # should show v22.x
+npm -v
+````
+
+:::
+
+:::tip
+If you use [**coursier**](https://get-coursier.io/), you can install Scala and sbt easily:
+```bash
+cs install scala sbt
+scala -version
+sbt -version
+````
+
+:::
+
+---
+
+## 2) Start PostgreSQL in Docker
+
+Run a local PostgreSQL instance dedicated to Daikoku:
+
+<Tabs>
+  <TabItem value="docker-run" label="docker run (simple)">
+
+```bash
+docker run --name daikoku-pg \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=default \
+  -p 5432:5432 \
+  -d postgres:17
+```
+
+  </TabItem>
+</Tabs>
+
+:::note Default connection info
+
+* **Host**: `localhost`
+* **Port**: `5432`
+* **Database**: `default`
+* **User / Password**: `postgres` / `postgres`
+  :::
+
+---
+
+## 3) Start the Frontend (Vite Dev Server)
+
+In **Terminal A**, go to the `javascript` folder and start the Vite development server:
+
+```bash
+cd $DAIKOKU_PROJECT_ROOT/daikoku/javascript
+npm install
+npm start
+```
+
+By default, the UI will run on **[http://localhost:5173](http://localhost:5173)**.
+
+---
+
+## 4) Prepare static files for backend (development mode)
+
+In **Terminal B**, copy the frontend `index.html` into the backend’s `public` folder so that the backend can serve the dev UI correctly:
+
+```bash
+cp $DAIKOKU_PROJECT_ROOT/daikoku/javascript/index.html \
+   $DAIKOKU_PROJECT_ROOT/daikoku/public/index.html
+```
+
+> This step ensures the backend and frontend stay in sync while developing.
+
+---
+
+## 5) Start the Backend in Hot Reload Mode
+
+In **Terminal B**, start the backend with `sbt` and enable continuous compilation:
+
+```bash
+cd $DAIKOKU_PROJECT_ROOT/daikoku
+sbt
+```
+
+Inside the `sbt` console:
+
+```sbt
+~run
+```
+
+This will automatically reload the backend each time you change Scala or configuration files.
+
+---
+
+## 6) Open the Application
+
+* **Frontend (Vite)**: [http://localhost:5173](http://localhost:5173)
+* **Backend (Play)**: runs on its default port (typically 9000, depending on config)
+
+👉 Open your browser at **[http://localhost:5173](http://localhost:5173)** to start working.
+
+---
+
+## Troubleshooting
+
+### Port 5173 already in use
+
+Change the Vite port (`--port 5174`) or stop the conflicting process.
+
+### PostgreSQL connection issues
+
+Make sure the container is running:
+
+```bash
+docker ps | grep daikoku-pg
+```
+
+Test database access:
+
+```bash
+docker exec -it daikoku-pg psql -U daikoku -d daikoku -c '\dt'
+```
+
+### sbt not reloading properly
+
+Ensure you’re running **JDK 21+** and clear the build cache if needed:
+
+```bash
+sbt clean
+```
+
+### Node dependency problems
+
+Clean and reinstall:
+
+```bash
+rm -rf node_modules package-lock.json
+npm install
+```
+
+---
+
+## Recommended Development Workflow
+
+1. **Backend** running in **Terminal B** with `sbt ~run` for live reload.
+2. **Frontend** running in **Terminal A** with `npm start` for HMR (hot module reload).
+3. Open **[http://localhost:5173](http://localhost:5173)** and iterate!
+
+---
+
+## Contribution Tips
+
+Before opening a pull request:
+
+* Run all available tests and linters.
+* Clearly describe:
+
+  * What problem or feature your change addresses.
+  * The potential impact or breaking changes.
+  * How to manually test your change.
+
+---
+
+Happy hacking 💥
+Welcome to the Daikoku developer community!


### PR DESCRIPTION
This PR introduces a new developer guide page to the Daikoku documentation.
It provides clear, step-by-step instructions to help new contributors set up a local development environment for Daikoku, including the backend, frontend, and PostgreSQL.

* Added a new page: `docs/16-dev.mdx`
* Covers installation prerequisites:
  * JDK 21+, Scala, sbt, Node.js 22, npm, Docker
* Instructions for:
  * Running PostgreSQL with Docker or Docker Compose
  * Starting the frontend (Vite) in dev mode
  * Preparing static assets for the backend
  * Running the backend with `sbt ~run` for hot reload
  * Accessing the dev environment at `http://localhost:5173`
* Includes troubleshooting tips and contribution guidelines

This guide aims to lower the entry barrier and make local development easier and faster for anyone who wants to contribute.
