### PR TITLE
fix: log "no session found" in debug instead of info

### DIFF
--- a/daikoku/app/fr/maif/daikoku/login/api.scala
+++ b/daikoku/app/fr/maif/daikoku/login/api.scala
@@ -365,7 +365,7 @@ class LoginFilter(env: Env)(implicit
                 LoginFilter
                   .handleWhitelistedRoute(request, tenant, nextFilter, env)
                   .getOrElse {
-                    AppLogger.info("no session found")
+                    AppLogger.debug("no session found")
                     nextFilter(request.addAttr(IdentityAttrs.TenantKey, tenant))
                   }
               case Some(sessionId) =>


### PR DESCRIPTION
When using Daikoku as unauthenticated user, logs are spammed with "no session found" log with INFO level.
This pollutes application log, therefore DEBUG is probably better suited for this kind of log.

## Description

Lower log level from info to debug for this specific log.

## Motivation and Context

See above description

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
