### PR TITLE
fix: remove useless cms download button

### DIFF
--- a/daikoku/javascript/src/components/adminbackoffice/cms/index.tsx
+++ b/daikoku/javascript/src/components/adminbackoffice/cms/index.tsx
@@ -5,7 +5,6 @@ import { Can, manage, tenant } from '../../utils';
 import { Create } from './Create';
 import { Pages } from './Pages';
 import * as Services from '../../../services';
-import { Spinner } from '../..';
 import { useTenantBackOffice } from '../../../contexts';
 import { GlobalContext } from '../../../contexts/globalContext';
 import { ICmsPageGQL } from '../../../types';
@@ -56,24 +55,6 @@ export const CMSOffice = () => {
     return (<div className="p-3">
       <div className="d-flex flex-row align-items-center justify-content-between mb-2">
         <h1 className="mb-0">Pages</h1>
-        <div>
-          <button className="btn btn-sm btn-outline-info" onClick={() => {
-            if (!downloading) {
-              setDownloading(true);
-              Services.downloadCmsFiles()
-                .then((transfer) => transfer.blob())
-                .then((bytes) => {
-                  const elm = document.createElement('a');
-                  elm.href = URL.createObjectURL(bytes);
-                  elm.setAttribute('download', 'cms.zip');
-                  elm.click();
-                  setDownloading(false);
-                });
-            }
-          }}>
-            {downloading ? (<Spinner heigth={18} width={18} />) : (translate('cms.export_all'))}
-          </button>
-        </div>
       </div>
 
       <Pages pages={cmsPages} reload={reload} />

--- a/daikoku/javascript/src/services/index.ts
+++ b/daikoku/javascript/src/services/index.ts
@@ -2280,12 +2280,6 @@ export const graphql = {
 `,
 };
 
-export const downloadCmsFiles = () =>
-  fetch('/api/cms/download', {
-    method: 'POST',
-    credentials: 'include',
-  });
-
 export const getDiffOfCmsPage = (id: any, diffId: any, showDiffs: any) =>
   customFetch(`/api/cms/pages/${id}/diffs/${diffId}?showDiffs=${showDiffs}`);
 


### PR DESCRIPTION
This only removes the button, since I couldn't fine associated route in backend routes. Moreover #1071 specified that removing route is out of scope for now.

Fix #1071