### PR TITLE
fix: prevent any key update from team "simple" users

### DIFF
--- a/daikoku/app/fr/maif/daikoku/controllers/ApiController.scala
+++ b/daikoku/app/fr/maif/daikoku/controllers/ApiController.scala
@@ -1648,7 +1648,7 @@ class ApiController(
 
   def updateApiSubscriptionCustomName(teamId: String, subscriptionId: String) =
     DaikokuAction.async(parse.json) { ctx =>
-      TeamApiKeyAction(
+      TeamAdminOnly(
         AuditTrailEvent(
           s"@{user.name} has update custom name for subscription @{subscription._id}"
         )
@@ -2256,7 +2256,7 @@ class ApiController(
 
   def toggleApiKeyRotation(teamId: String, subscriptionId: String) =
     DaikokuAction.async(parse.json) { ctx =>
-      TeamApiKeyAction(
+      TeamAdminOnly(
         AuditTrailEvent(
           s"@{user.name} has toggle api subscription rotation @{subscription.id} of @{team.name} - @{team.id}"
         )

--- a/daikoku/app/fr/maif/daikoku/controllers/ApiController.scala
+++ b/daikoku/app/fr/maif/daikoku/controllers/ApiController.scala
@@ -2018,7 +2018,7 @@ class ApiController(
       enabled: Option[Boolean]
   ) =
     DaikokuAction.async { ctx =>
-      TeamApiKeyAction(
+      TeamAdminOnly(
         AuditTrailEvent(
           s"@{user.name} has @{action} api subscription @{subscription.id} of @{team.name} - @{team.id}"
         )
@@ -2289,7 +2289,7 @@ class ApiController(
 
   def regenerateApiKeySecret(teamId: String, subscriptionId: String) =
     DaikokuAction.async { ctx =>
-      TeamApiKeyAction(
+      TeamAdminOnly(
         AuditTrailEvent(
           s"@{user.name} has regenerate apikey secret @{subscription.id} of @{team.name} - @{team.id}"
         )

--- a/daikoku/javascript/src/components/backoffice/apikeys/TeamApiKeys.tsx
+++ b/daikoku/javascript/src/components/backoffice/apikeys/TeamApiKeys.tsx
@@ -14,9 +14,11 @@ import { Table, TableRef } from '../../inputs';
 import {
   Can,
   Spinner,
+  access,
   apikey,
   isUserIsTeamAdmin,
   manage,
+  read,
   teamPermissions,
 } from '../../utils';
 
@@ -94,7 +96,7 @@ export const TeamApiKeys = () => {
     return <Spinner />;
   } else if (currentTeam && !isError(currentTeam)) {
     return (
-      <Can I={manage} a={apikey} team={currentTeam} dispatchError={true}>
+      <Can I={access} a={apikey} team={currentTeam} dispatchError={true}>
         <div className="row">
           <div className="col">
             <h1>

--- a/daikoku/javascript/src/components/backoffice/apikeys/TeamApiKeysForApi.tsx
+++ b/daikoku/javascript/src/components/backoffice/apikeys/TeamApiKeysForApi.tsx
@@ -34,6 +34,7 @@ import {
   apikey,
   escapeRegExp,
   formatDate,
+  manage,
   read
 } from '../../utils';
 import { apiGQLToLegitApi } from '../../utils/apiUtils';
@@ -938,90 +939,92 @@ export const ApiKeyCard = ({
           {translate("subscription.nota.part.2")}
           <Link className='cursor-pointer underline mx-1' to={statsLink}>{translate("subscription.nota.link.statistics")}</Link>
         </div>
-        <div
-          className="dropdown"
-          style={{
-            position: 'absolute',
-            top: '15px',
-            right: '15px'
-          }}
-        >
-          <i
-            className="fa fa-bars cursor-pointer dropdown-menu-button"
-            style={{ fontSize: '20px' }}
-            data-bs-toggle="dropdown"
-            aria-expanded="false"
-            id="dropdownMenuButton"
-          />
-          <div className="dropdown-menu" aria-labelledby="dropdownMenuButton" style={{ zIndex: 1 }}>
-            <span
-              className="dropdown-item cursor-pointer"
-              onClick={() => openFormModal({
-                title: translate("subscription.custom.name.update.label"),
-                actionLabel: translate('Save'),
-                schema: {
-                  customName: {
-                    type: type.string,
-                    placeholder: translate('subscription.custom.name.update.placeholder'),
-                    label: translate('subscription.custom.name.update.message'),
-                  }
-                },
-                onSubmit: (data) => {
-                  updateCustomName(data.customName ?? '')
-                },
-                value: { customName: subscription.customName }
-              })}
-            >
-              {translate("subscription.custom.name.update.label")}
-            </span>
-            <div className="dropdown-divider" />
-            {!subscription.parent && !disableRotation && <span
-              className="dropdown-item cursor-pointer"
-              onClick={() => openFormModal({
-                title: translate("ApiKey rotation"),
-                actionLabel: translate('Save'),
-                schema: settingsSchema,
-                onSubmit: (data) => handleChanges(data),
-                value: subscription.rotation
-              })}
-            >
-              {translate("subscription.rotation.update.label")}
-            </span>}
-            {!subscription.parent && <span
-              className="dropdown-item cursor-pointer "
-              onClick={() => withLoader(transferKey)}
-            >
-              {translate("subscription.transfer.label")}
-            </span>}
-            <span
-              className={classNames("dropdown-item cursor-pointer", {
-                disabled: subscription.parent && !subscription.parentUp
-              })}
-              onClick={() => withLoader(toggle)}
-            >
-              {subscription.enabled ? translate("subscription.disable.button.label") : translate("subscription.enable.button.label")}
-            </span>
-            <div className="dropdown-divider" />
-            {!subscription.parent && <span
-              className="dropdown-item cursor-pointer danger"
-              onClick={() => withLoader(regenerateSecret)}
-            >
-              {translate("subscription.reset.secret.label")}
-            </span>}
-            {subscription.parent && <span
-              className="dropdown-item cursor-pointer danger"
-              onClick={() => withLoader(() => makeUniqueApiKey(detailQuery.data))}
-            >
-              {translate("subscription.extract.button.label")}
-            </span>}
-            <span
-              className="dropdown-item cursor-pointer danger"
-              onClick={() => withLoader(() => deleteApiKey(detailQuery.data))}
-            >
-              {translate("subscription.delete.button.label")}
-            </span>
+        <Can I={manage} a={apikey} team={currentTeam} >
+          <div
+            className="dropdown"
+            style={{
+              position: 'absolute',
+              top: '15px',
+              right: '15px'
+            }}
+          >
+            <i
+              className="fa fa-bars cursor-pointer dropdown-menu-button"
+              style={{ fontSize: '20px' }}
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+              id="dropdownMenuButton"
+            />
+            <div className="dropdown-menu" aria-labelledby="dropdownMenuButton" style={{ zIndex: 1 }}>
+              <span
+                className="dropdown-item cursor-pointer"
+                onClick={() => openFormModal({
+                  title: translate("subscription.custom.name.update.label"),
+                  actionLabel: translate('Save'),
+                  schema: {
+                    customName: {
+                      type: type.string,
+                      placeholder: translate('subscription.custom.name.update.placeholder'),
+                      label: translate('subscription.custom.name.update.message'),
+                    }
+                  },
+                  onSubmit: (data) => {
+                    updateCustomName(data.customName ?? '')
+                  },
+                  value: { customName: subscription.customName }
+                })}
+              >
+                {translate("subscription.custom.name.update.label")}
+              </span>
+              <div className="dropdown-divider" />
+              {!subscription.parent && !disableRotation && <span
+                className="dropdown-item cursor-pointer"
+                onClick={() => openFormModal({
+                  title: translate("ApiKey rotation"),
+                  actionLabel: translate('Save'),
+                  schema: settingsSchema,
+                  onSubmit: (data) => handleChanges(data),
+                  value: subscription.rotation
+                })}
+              >
+                {translate("subscription.rotation.update.label")}
+              </span>}
+              {!subscription.parent && <span
+                className="dropdown-item cursor-pointer "
+                onClick={() => withLoader(transferKey)}
+              >
+                {translate("subscription.transfer.label")}
+              </span>}
+              <span
+                className={classNames("dropdown-item cursor-pointer", {
+                  disabled: subscription.parent && !subscription.parentUp
+                })}
+                onClick={() => withLoader(toggle)}
+              >
+                {subscription.enabled ? translate("subscription.disable.button.label") : translate("subscription.enable.button.label")}
+              </span>
+              <div className="dropdown-divider" />
+              {!subscription.parent && <span
+                className="dropdown-item cursor-pointer danger"
+                onClick={() => withLoader(regenerateSecret)}
+              >
+                {translate("subscription.reset.secret.label")}
+              </span>}
+              {subscription.parent && <span
+                className="dropdown-item cursor-pointer danger"
+                onClick={() => withLoader(() => makeUniqueApiKey(detailQuery.data))}
+              >
+                {translate("subscription.extract.button.label")}
+              </span>}
+              <span
+                className="dropdown-item cursor-pointer danger"
+                onClick={() => withLoader(() => deleteApiKey(detailQuery.data))}
+              >
+                {translate("subscription.delete.button.label")}
+              </span>
+            </div>
           </div>
-        </div>
+        </Can>
       </div>
     )
   } else {

--- a/daikoku/javascript/src/components/utils/permissions/permissions.ts
+++ b/daikoku/javascript/src/components/utils/permissions/permissions.ts
@@ -25,7 +25,7 @@ export const permissions: {
 } = {
   User: [
     {
-      action: manage,
+      action: read,
       what: apikey,
       condition: (team: ITeamSimple) => !team.apiKeyVisibility || team.apiKeyVisibility === 'User',
     },
@@ -38,7 +38,7 @@ export const permissions: {
   ApiEditor: [
     { action: manage, what: api },
     {
-      action: manage,
+      action: read,
       what: apikey,
       condition: (team: any) => team.apiKeyVisibility !== 'Administrator',
     },

--- a/daikoku/javascript/tests/specs/consultation.spec.ts
+++ b/daikoku/javascript/tests/specs/consultation.spec.ts
@@ -433,7 +433,6 @@ test('Voir ses notifications', async ({ page }) => {
   await expect(page.locator('article')).toHaveCount(50)
   await expect(page.getByRole('button', { name: "Afficher plus de notifications", exact: true })).toBeEnabled();
   await page.getByRole('button', { name: "Afficher plus de notifications", exact: true }).click();
-  await page.getByRole('button', { name: "Afficher plus de notifications", exact: true }).click();
   await expect(page.locator('article')).toHaveCount(58)
   await expect(page.getByRole('button', { name: "Afficher plus de notifications", exact: true })).toBeHidden();
   await page.locator('div.daikoku-select__control').filter({ hasText: /^Toutes les équipes/ }).locator('svg').click();

--- a/daikoku/javascript/tests/specs/consultation.spec.ts
+++ b/daikoku/javascript/tests/specs/consultation.spec.ts
@@ -433,6 +433,7 @@ test('Voir ses notifications', async ({ page }) => {
   await expect(page.locator('article')).toHaveCount(50)
   await expect(page.getByRole('button', { name: "Afficher plus de notifications", exact: true })).toBeEnabled();
   await page.getByRole('button', { name: "Afficher plus de notifications", exact: true }).click();
+  await page.getByRole('button', { name: "Afficher plus de notifications", exact: true }).click();
   await expect(page.locator('article')).toHaveCount(58)
   await expect(page.getByRole('button', { name: "Afficher plus de notifications", exact: true })).toBeHidden();
   await page.locator('div.daikoku-select__control').filter({ hasText: /^Toutes les équipes/ }).locator('svg').click();

--- a/daikoku/javascript/tests/specs/souscriptions.spec.ts
+++ b/daikoku/javascript/tests/specs/souscriptions.spec.ts
@@ -1,8 +1,13 @@
 import test, { expect } from '@playwright/test';
 import otoroshi_data from '../config/otoroshi/otoroshi-state.json';
+<<<<<<< HEAD
 import { generateApi, generatePlan, saveApi, savePlan } from './apis';
 import { JIM, MICHAEL } from './users';
 import { ACCUEIL, adminApikeyId, adminApikeySecret, apiDivision, EMAIL_UI, exposedPort, findAndGoToTeam, HOME, loginAs, logistiqueCommandeProdApiKeyId, logout, otoroshiAdminApikeyId, otoroshiAdminApikeySecret, otoroshiDevCommandRouteId, otoroshiDevPaperRouteId, vendeurs, vendeursPapierExtendedDevApiKeyId } from './utils';
+=======
+import { DWIGHT, IUser, JIM, MICHAEL } from './users';
+import { ACCUEIL, adminApikeyId, adminApikeySecret, EMAIL_UI, exposedPort, findAndGoToTeam, HOME, loginAs, logistiqueCommandeProdApiKeyId, logout, otoroshiAdminApikeyId, otoroshiAdminApikeySecret, otoroshiDevCommandRouteId, otoroshiDevPaperRouteId, vendeursPapierExtendedDevApiKeyId } from './utils';
+>>>>>>> 6a688bd0f (test: key edition burger button should not be visible in frontend for non admin)
 
 test.beforeEach(async () => {
   await Promise.all([
@@ -956,3 +961,58 @@ test('[#1096] - visibilité du bouton de souscription selon la visibilité API/p
   await page.getByText('Environnements').click();
   await expect(page.locator('[data-usage-plan="prod"]').getByRole('button', { name: getKey })).toBeVisible();
 })
+test("[] - [Consommateur] - les actions d'administration des clés doivent être accessibles uniquement aux admins d'une équipe", async({page, context}) => {
+
+  async function checkBurgerButtonVisibility(visible: Boolean) {
+    const keyUrl = `${HOME}vendeurs/settings/apikeys/api-commande/1.0.0`
+    const burgerLocator = page.locator('.api-subscription').first().locator('#dropdownMenuButton')
+    await page.goto(keyUrl)
+
+    if(visible) {
+      await expect(burgerLocator).toBeVisible()
+    } else {
+      // Ensure that api key card is displayed before asserting on burger button absence
+      await expect(page.getByRole("button", {name: "Copier le clientId et le clientSecret"})).toBeVisible()
+      await expect(burgerLocator).not.toBeVisible()
+    }
+  }
+
+  async function updateDwightRightsOnVendeurTeam(right: "Editor" | "Admin") {
+    const dwightUserLocator = page.locator(".container", { hasText: DWIGHT.name })
+    await page.goto(`${HOME}vendeurs/settings/members`)
+    await dwightUserLocator.locator(".overlay").hover()
+    await dwightUserLocator.locator(".fa-user-cog").click();
+    if(right === "Editor") {
+      await dwightUserLocator.locator(".fa-pencil-alt").click();
+      await expect(page.getByText("Dwight Schrute est maintenant ApiEditor")).toBeVisible()
+    } else {
+      await dwightUserLocator.locator(".fa-shield-alt").click();
+      await expect(page.getByText("Dwight Schrute est maintenant Administrator")).toBeVisible()
+    }
+  }
+
+
+  await page.goto(ACCUEIL);
+  await loginAs(DWIGHT, page);
+  await checkBurgerButtonVisibility(false);
+
+  await logout(page)
+  await page.goto(ACCUEIL);
+  await loginAs(MICHAEL, page);
+  await checkBurgerButtonVisibility(true);
+  await updateDwightRightsOnVendeurTeam("Editor")
+
+  await logout(page)
+  await loginAs(DWIGHT, page);
+  await checkBurgerButtonVisibility(false);
+
+  await logout(page)
+  await page.goto(ACCUEIL);
+  await loginAs(MICHAEL, page);
+  await updateDwightRightsOnVendeurTeam("Admin")
+
+  await logout(page)
+  await loginAs(DWIGHT, page);
+  await checkBurgerButtonVisibility(true);
+})
+

--- a/daikoku/javascript/tests/specs/souscriptions.spec.ts
+++ b/daikoku/javascript/tests/specs/souscriptions.spec.ts
@@ -1,10 +1,8 @@
 import test, { expect } from '@playwright/test';
 import otoroshi_data from '../config/otoroshi/otoroshi-state.json';
 import { generateApi, generatePlan, saveApi, savePlan } from './apis';
-import { JIM, MICHAEL } from './users';
+import { JIM, MICHAEL, IUser, DWIGHT } from './users';
 import { ACCUEIL, adminApikeyId, adminApikeySecret, apiDivision, EMAIL_UI, exposedPort, findAndGoToTeam, HOME, loginAs, logistiqueCommandeProdApiKeyId, logout, otoroshiAdminApikeyId, otoroshiAdminApikeySecret, otoroshiDevCommandRouteId, otoroshiDevPaperRouteId, vendeurs, vendeursPapierExtendedDevApiKeyId } from './utils';
-import { DWIGHT, IUser, JIM, MICHAEL } from './users';
-import { ACCUEIL, adminApikeyId, adminApikeySecret, EMAIL_UI, exposedPort, findAndGoToTeam, HOME, loginAs, logistiqueCommandeProdApiKeyId, logout, otoroshiAdminApikeyId, otoroshiAdminApikeySecret, otoroshiDevCommandRouteId, otoroshiDevPaperRouteId, vendeursPapierExtendedDevApiKeyId } from './utils';
 
 
 test.beforeEach(async () => {

--- a/daikoku/javascript/tests/specs/souscriptions.spec.ts
+++ b/daikoku/javascript/tests/specs/souscriptions.spec.ts
@@ -1,13 +1,11 @@
 import test, { expect } from '@playwright/test';
 import otoroshi_data from '../config/otoroshi/otoroshi-state.json';
-<<<<<<< HEAD
 import { generateApi, generatePlan, saveApi, savePlan } from './apis';
 import { JIM, MICHAEL } from './users';
 import { ACCUEIL, adminApikeyId, adminApikeySecret, apiDivision, EMAIL_UI, exposedPort, findAndGoToTeam, HOME, loginAs, logistiqueCommandeProdApiKeyId, logout, otoroshiAdminApikeyId, otoroshiAdminApikeySecret, otoroshiDevCommandRouteId, otoroshiDevPaperRouteId, vendeurs, vendeursPapierExtendedDevApiKeyId } from './utils';
-=======
 import { DWIGHT, IUser, JIM, MICHAEL } from './users';
 import { ACCUEIL, adminApikeyId, adminApikeySecret, EMAIL_UI, exposedPort, findAndGoToTeam, HOME, loginAs, logistiqueCommandeProdApiKeyId, logout, otoroshiAdminApikeyId, otoroshiAdminApikeySecret, otoroshiDevCommandRouteId, otoroshiDevPaperRouteId, vendeursPapierExtendedDevApiKeyId } from './utils';
->>>>>>> 6a688bd0f (test: key edition burger button should not be visible in frontend for non admin)
+
 
 test.beforeEach(async () => {
   await Promise.all([

--- a/daikoku/test/fr/maif/daikoku/controllers/ApiControllerSpec.scala
+++ b/daikoku/test/fr/maif/daikoku/controllers/ApiControllerSpec.scala
@@ -6642,15 +6642,15 @@ class ApiControllerSpec()
         ),
         (
           Some(TeamApiKeyVisibility.ApiEditor),
-          Map((sessionAdmin, 200), (sessionApiEditor, 200), (sessionUser, 403))
+          Map((sessionAdmin, 200), (sessionApiEditor, 403), (sessionUser, 403))
         ),
         (
           Some(TeamApiKeyVisibility.User),
-          Map((sessionAdmin, 200), (sessionApiEditor, 200), (sessionUser, 200))
+          Map((sessionAdmin, 200), (sessionApiEditor, 403), (sessionUser, 403))
         ),
         (
           None,
-          Map((sessionAdmin, 200), (sessionApiEditor, 200), (sessionUser, 200))
+          Map((sessionAdmin, 200), (sessionApiEditor, 403), (sessionUser, 403))
         )
       )
 
@@ -6720,15 +6720,15 @@ class ApiControllerSpec()
         ),
         (
           Some(TeamApiKeyVisibility.ApiEditor),
-          Map((sessionAdmin, 200), (sessionApiEditor, 200), (sessionUser, 403))
+          Map((sessionAdmin, 200), (sessionApiEditor, 403), (sessionUser, 403))
         ),
         (
           Some(TeamApiKeyVisibility.User),
-          Map((sessionAdmin, 200), (sessionApiEditor, 200), (sessionUser, 200))
+          Map((sessionAdmin, 200), (sessionApiEditor, 403), (sessionUser, 403))
         ),
         (
           None,
-          Map((sessionAdmin, 200), (sessionApiEditor, 200), (sessionUser, 200))
+          Map((sessionAdmin, 200), (sessionApiEditor, 403), (sessionUser, 403))
         )
       )
 
@@ -6996,15 +6996,15 @@ class ApiControllerSpec()
         ),
         (
           Some(TeamApiKeyVisibility.ApiEditor),
-          Map((sessionAdmin, 200), (sessionApiEditor, 200), (sessionUser, 403))
+          Map((sessionAdmin, 200), (sessionApiEditor, 403), (sessionUser, 403))
         ),
         (
           Some(TeamApiKeyVisibility.User),
-          Map((sessionAdmin, 200), (sessionApiEditor, 200), (sessionUser, 200))
+          Map((sessionAdmin, 200), (sessionApiEditor, 403), (sessionUser, 403))
         ),
         (
           None,
-          Map((sessionAdmin, 200), (sessionApiEditor, 200), (sessionUser, 200))
+          Map((sessionAdmin, 200), (sessionApiEditor, 403), (sessionUser, 403))
         )
       )
 

--- a/daikoku/test/fr/maif/daikoku/usages/OtoroshiSyncSpec.scala
+++ b/daikoku/test/fr/maif/daikoku/usages/OtoroshiSyncSpec.scala
@@ -1314,7 +1314,7 @@ class OtoroshiSyncSpec()
           Seq(consumerParentDevSubscription, consumerChildDevSubscription)
       )
 
-      val session = loginWithBlocking(user, tenant)
+      val session = loginWithBlocking(userAdmin, tenant)
       val resp = httpJsonCallBlocking(
         path =
           s"/api/teams/${teamConsumerId.value}/subscriptions/${consumerChildDevSubscription.id.value}/_archive",
@@ -1464,7 +1464,7 @@ class OtoroshiSyncSpec()
           Seq(consumerParentDevSubscription, consumerChildDevSubscription)
       )
 
-      val session = loginWithBlocking(user, tenant)
+      val session = loginWithBlocking(userAdmin, tenant)
       val resp = httpJsonCallBlocking(
         path =
           s"/api/teams/${teamConsumerId.value}/subscriptions/${consumerParentDevSubscription.id.value}/_archive",


### PR DESCRIPTION
Remaining work:

- [x] update permission on personnal name update endpoint
- [x] update permission on key rotation endpoint
- [x] update permission on subscription activation endpoint
- [x] update permission on subscription transfer endpoint
- [x] update permission on secret reset endpoint
- [x] test with playwright that burger button is not visible anymore for simple user
- [x] also test that endpoints does not work when calling directly with simple user cookie