### PR TITLE
fix: some flakky tests

### DIFF
--- a/daikoku/javascript/tests/specs/admin_dk.spec.ts
+++ b/daikoku/javascript/tests/specs/admin_dk.spec.ts
@@ -73,18 +73,28 @@ test('[ASOAPI-10506] - Supprimer définitivement un utilisateur ', async ({ page
 
 test('[ASOAPI-10506] - Supprimer définitivement un utilisateur (cas particulier d\'utilisateur avec APIkey active)', async ({ page }) => {
   //l'utilisateur qui a deja une clé d'api est dwight
+
   const getDwightAvatar = (): Locator => {
     return page.locator(".avatar-with-action__infos", { hasText: DWIGHT.name })
   }
 
-  const beginningKey = await fetch(`http://otoroshi-api.oto.tools:8080/apis/apim.otoroshi.io/v1/apikeys/${dwightPaperApiKeyId}`, {
-    method: 'GET',
-    headers: {
-      "Otoroshi-Client-Id": otoroshiAdminApikeyId,
-      "Otoroshi-Client-Secret": otoroshiAdminApikeySecret,
-    },
-  })
-  await expect(beginningKey.status).toBe(200)
+  await expect.poll(async () => {
+    const beginningKey = await fetch(`http://otoroshi-api.oto.tools:8080/apis/apim.otoroshi.io/v1/apikeys/${dwightPaperApiKeyId}`, {
+      method: 'GET',
+      headers: {
+        "Otoroshi-Client-Id": otoroshiAdminApikeyId,
+        "Otoroshi-Client-Secret": otoroshiAdminApikeySecret,
+      },
+    });
+    return beginningKey.status;
+  }, {
+    // Custom expect message for reporting, optional.
+    message: 'Retrieve dwightPaperApiKey',
+    // Poll for 10 seconds; defaults to 5 seconds. Pass 0 to disable timeout.
+    timeout: 10_000,
+  }).toBe(200);
+
+
 
   await page.goto(ACCUEIL);
   await loginAs(MICHAEL, page)

--- a/daikoku/javascript/tests/specs/api_mgmt.spec.ts
+++ b/daikoku/javascript/tests/specs/api_mgmt.spec.ts
@@ -169,7 +169,7 @@ test('[ASOAPI-10599] - supprimer une API', async ({ page }) => {
   await page.getByLabel('Saisissez API papier pour').click();
   await page.getByLabel('Saisissez API papier pour').fill('API papier');
   await page.getByRole('button', { name: 'Confirmation' }).click();
-  await expect(page.getByRole('listitem', { name: 'API papier' })).toBeHidden();
+  await expect(page.getByText("Supprimé avec succès")).toBeVisible()
 
   await page.getByRole('button', { name: 'Taper / pour rechercher' }).click();
   await page.getByRole('textbox', { name: 'Rechercher une API, équipe,' }).fill('vendeurs');


### PR DESCRIPTION
Fix two flakky tests:

- One by using playwright `expect.poll` to wait a correct response from otoroshi
- Another by making sure API deletion is completed before navigating