### PR TITLE
Fix/perf flakyness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,18 +129,22 @@ jobs:
             compose-file: ./daikoku/javascript/tests/docker-compose-ldap.yml
             playwright-config: playwright.config.js
             health-url: http://localhost:13200/health
+            otoroshi-health-url: http://otoroshi-api.oto.tools:8080/health
           - name: oidc
             compose-file: ./daikoku/javascript/tests/docker-compose-oidc.yml
             playwright-config: playwright.oidc.config.js
             health-url: http://localhost:13200/health
+            otoroshi-health-url: http://otoroshi-api.oto.tools:8080/health
           - name: local
             compose-file: ./daikoku/javascript/tests/docker-compose-local.yml
             playwright-config: playwright.local.config.js
             health-url: http://localhost:13200/health
+            otoroshi-health-url: http://otoroshi-api.oto.tools:8080/health
           - name: perf
             compose-file: ./daikoku/javascript/tests/docker-compose-ldap.yml
             playwright-config: playwright.perf.config.js
             health-url: http://localhost:13200/health
+            otoroshi-health-url: http://otoroshi-api.oto.tools:8080/health
     name: "test-${{ matrix.suite.name }}"
     steps:
       - uses: actions/checkout@v4
@@ -174,12 +178,21 @@ jobs:
 
       - name: Wait for API to be ready
         run: |
-          echo "Waiting for services to be up..."
+          echo "Waiting for Daikoku to be up..."
           until curl --silent --fail ${{ matrix.suite.health-url }}; do
             printf '.'
             sleep 2
           done
           echo "daikoku is ready!"
+
+      - name: Wait for otoroshi to be ready
+        run: |
+          echo "Waiting for Otoroshi to be up..."
+          until curl --silent --fail ${{ matrix.suite.otoroshi-health-url }}; do
+            printf '.'
+            sleep 2
+          done
+          echo "otoroshi is ready!"
 
       - name: Install Playwright
         timeout-minutes: 10

--- a/daikoku/javascript/tests/specs/admin_dk.spec.ts
+++ b/daikoku/javascript/tests/specs/admin_dk.spec.ts
@@ -73,18 +73,28 @@ test('[ASOAPI-10506] - Supprimer définitivement un utilisateur ', async ({ page
 
 test('[ASOAPI-10506] - Supprimer définitivement un utilisateur (cas particulier d\'utilisateur avec APIkey active)', async ({ page }) => {
   //l'utilisateur qui a deja une clé d'api est dwight
+
   const getDwightAvatar = (): Locator => {
     return page.locator(".avatar-with-action__infos", { hasText: DWIGHT.name })
   }
 
-  const beginningKey = await fetch(`http://otoroshi-api.oto.tools:8080/apis/apim.otoroshi.io/v1/apikeys/${dwightPaperApiKeyId}`, {
-    method: 'GET',
-    headers: {
-      "Otoroshi-Client-Id": otoroshiAdminApikeyId,
-      "Otoroshi-Client-Secret": otoroshiAdminApikeySecret,
-    },
-  })
-  await expect(beginningKey.status).toBe(200)
+  await expect.poll(async () => {
+    const beginningKey = await fetch(`http://otoroshi-api.oto.tools:8080/apis/apim.otoroshi.io/v1/apikeys/${dwightPaperApiKeyId}`, {
+      method: 'GET',
+      headers: {
+        "Otoroshi-Client-Id": otoroshiAdminApikeyId,
+        "Otoroshi-Client-Secret": otoroshiAdminApikeySecret,
+      },
+    });
+    return beginningKey.status;
+  }, {
+    // Custom expect message for reporting, optional.
+    message: 'Retrieve dwightPaperApiKey',
+    // Poll for 10 seconds; defaults to 5 seconds. Pass 0 to disable timeout.
+    timeout: 10_000,
+  }).toBe(200);
+
+
 
   await page.goto(ACCUEIL);
   await loginAs(MICHAEL, page)

--- a/daikoku/javascript/tests/specs/api_mgmt.spec.ts
+++ b/daikoku/javascript/tests/specs/api_mgmt.spec.ts
@@ -169,7 +169,7 @@ test('[ASOAPI-10599] - supprimer une API', async ({ page }) => {
   await page.getByLabel('Saisissez API papier pour').click();
   await page.getByLabel('Saisissez API papier pour').fill('API papier');
   await page.getByRole('button', { name: 'Confirmation' }).click();
-  await expect(page.getByRole('listitem', { name: 'API papier' })).toBeHidden();
+  await expect(page.getByText("Supprimé avec succès")).toBeVisible()
 
   await page.getByRole('button', { name: 'Taper / pour rechercher' }).click();
   await page.getByRole('textbox', { name: 'Rechercher une API, équipe,' }).fill('vendeurs');


### PR DESCRIPTION
Fix perf test flakyness.

Sometimes seed perf test failed due to Daikoku being ready before Otoroshi, making first call to Otoroshi fail, and with it the while perf test.

This fixes the issue by waiting both for Daikoku AND Otoroshi before proceeding.