### PR TITLE
fix: add line jump in env aggregation tooltip

### DIFF
--- a/daikoku/javascript/src/locales/en/translation.json
+++ b/daikoku/javascript/src/locales/en/translation.json
@@ -967,7 +967,7 @@
     "aggregation_apikeys.security.help": "Enable the possibility to use an API key on multiple APIs",
     "aggregation_apikeys.environment.security.help": "Enable the possibility to use an API key on multiple APIs having the same environment.",
     "aggregation.api_key.security.notification": "You're enabled the aggregation of API keys. It's an advanced usage of the API keys. Keep in mind that the metadata and the quotas will be shared between the parent API key and his aggregate API keys. Daikoku will not apply any control when conflict metadata.",
-    "aggregation.environment.api_key.security.notification": "Even with aggregation security enabled, a check is performed to verify the usage plan names when extending one subscription to another. This ensures that API keys can only be aggregated within compatible environments.",
+    "aggregation.environment.api_key.security.notification": "Even with aggregation security enabled, a check is performed to verify the usage<br/>plan names when extending one subscription to another.<br/>This ensures that API keys can only be aggregated within compatible environments.",
     "disabled.due.to.aggregation.security": "disabled due to enabling of aggregation security",
     "I understood": "I understood",
     "team_apikey_for_api.make_unique": "Make unique",

--- a/daikoku/javascript/src/locales/fr/translation.json
+++ b/daikoku/javascript/src/locales/fr/translation.json
@@ -967,7 +967,7 @@
   "aggregation_apikeys.security.help": "Active la possibilité d'utiliser une même clé d'API sur plusieurs plans.",
   "aggregation_apikeys.environment.security.help": "Active la possibilité d'utiliser une même clé d'API sur plusieurs plans ayant le même environnement.",
   "aggregation.api_key.security.notification": "L'agrégation des clés API est une utilisation avancée. Gardez à l'esprit que les métadonnées et les quotas seront partagés entre chaque clé d'API parente et ses clés d'API agrégées. Daikoku n'appliquera aucun contrôle en cas de conflit de métadonnées.",
-  "aggregation.environment.api_key.security.notification": "Même si la sécurité d'agrégation est activée, un contrôle est effectué pour vérifier les noms des plans d'utilisation lorsque vous étendez une souscription à une autre. Cela garantit que les clés API ne peuvent être agrégées que dans des environnements compatibles.",
+  "aggregation.environment.api_key.security.notification": "Même si la sécurité d'agrégation est activée, un contrôle est effectué pour vérifier<br/>les noms des plans d'utilisation lorsque vous étendez une souscription à une autre.<br/>Cela garantit que les clés API ne peuvent être agrégées que dans des environnements compatibles.",
   "disabled.due.to.aggregation.security": "désactivé en raison de l'activation de l'aggégation des clés",
   "I understood": "J'ai compris",
   "team_apikey_for_api.make_unique": "Rendre unique",


### PR DESCRIPTION
Tooltip content was too long for most of the screens.

Tooltip is not on 3 lines, however there is a transparency issue with below content (see below screenshot).

Adding a z-index: 1 to the tooltip solves this, but it may be better to do this in react-forms.

<img width="1679" height="581" alt="image" src="https://github.com/user-attachments/assets/2e1b602e-bcdd-4be5-b714-98a50fc57704" />
