### PR TITLE
fix: prevent key deletion to remove key team from private plan

### DIFF
--- a/daikoku/app/fr/maif/daikoku/controllers/ApiController.scala
+++ b/daikoku/app/fr/maif/daikoku/controllers/ApiController.scala
@@ -2336,12 +2336,6 @@ class ApiController(
           (api: Api, plan: UsagePlan, subscription: ApiSubscription) => {
             ctx.setCtxValue("subscription", subscription)
 
-            val cleanupPrivatePlan: EitherT[Future, AppError, Unit] =
-              if (plan.visibility == Private)
-                EitherT.right(env.dataStore.usagePlanRepo.forTenant(ctx.tenant)
-                  .save(plan.removeAuthorizedTeam(team.id)).map(_ => ()))
-              else EitherT.pure(())
-
             val done = Json.obj("archive" -> "done", "subscriptionId" -> subscriptionId)
 
             EitherT.liftF(env.dataStore.apiSubscriptionRepo.forTenant(ctx.tenant)
@@ -2351,7 +2345,6 @@ class ApiController(
                   // standalone or child: delegate entirely to DeletionService
                   for {
                     _ <- deletionService.deleteSubscriptions(Seq(subscription), api, ctx.tenant)
-                    _ <- if (subscription.parent.isEmpty) cleanupPrivatePlan else EitherT.pure[Future, AppError](())
                   } yield done
 
                 case childs: Seq[ApiSubscription] => action match {
@@ -2359,7 +2352,6 @@ class ApiController(
                     // delete all children + parent in one shot
                     for {
                       _ <- deletionService.deleteSubscriptions(childs ++ Seq(subscription), api, ctx.tenant)
-                      _ <- cleanupPrivatePlan
                     } yield done
 
                   case Some("extraction") =>
@@ -2367,7 +2359,6 @@ class ApiController(
                     for {
                       _ <- apiService.condenseEitherT(childs.map(s => EitherT(_makeUnique(ctx.tenant, plan, s, ctx.user))))
                       _ <- deletionService.deleteSubscriptions(Seq(subscription), api, ctx.tenant)
-                      _ <- cleanupPrivatePlan
                     } yield done
 
                   case _ =>

--- a/daikoku/test/fr/maif/daikoku/controllers/ApiControllerSpec.scala
+++ b/daikoku/test/fr/maif/daikoku/controllers/ApiControllerSpec.scala
@@ -6418,6 +6418,81 @@ class ApiControllerSpec()
     }
   }
 
+  "a deletion of a key" must {
+    "not remove team from authorized teams if plan is private" in {
+      val plan = UsagePlan(
+        id = UsagePlanId(IdGenerator.token),
+        tenant = tenant.id,
+        customName = "MyPrivatePlan",
+        customDescription = None,
+        otoroshiTarget = Some(
+          OtoroshiTarget(
+            OtoroshiSettingsId("default"),
+            Some(
+              AuthorizedEntities(groups = Set(OtoroshiServiceGroupId("12345")))
+            )
+          )
+        ),
+        allowMultipleKeys = Some(false),
+        visibility = Private,
+        authorizedTeams = Seq(teamConsumerId),
+        autoRotation = Some(false),
+        subscriptionProcess = Seq.empty,
+        integrationProcess = IntegrationProcess.ApiKey
+      )
+      val payperUseSub = ApiSubscription(
+        id = ApiSubscriptionId("test-removal"),
+        tenant = tenant.id,
+        apiKey = OtoroshiApiKey("name", "id", "secret"),
+        plan = plan.id,
+        createdAt = DateTime.now(),
+        team = teamConsumerId,
+        api = defaultApi.api.id,
+        by = daikokuAdminId,
+        customName = None,
+        rotation = None,
+        integrationToken = "test-removal"
+      )
+
+      setupEnvBlocking(
+        tenants = Seq(tenant),
+        users = Seq(userAdmin),
+        teams = Seq(
+          teamOwner,
+          teamConsumer
+        ),
+        usagePlans = Seq(plan),
+        apis = Seq(
+          defaultApi.api.copy(
+            possibleUsagePlans = Seq(plan.id)
+          )
+        ),
+        subscriptions = Seq(payperUseSub)
+      )
+
+      val session = loginWithBlocking(userAdmin, tenant)
+
+      val resp = httpJsonCallBlocking(
+        path =
+          s"/api/teams/${teamOwnerId.value}/subscriptions/${payperUseSub.id.value}?action=delete",
+        method = "DELETE"
+      )(using tenant, session)
+
+      resp.status mustBe 200
+
+
+      val planAuthorizedTeamCheck = httpJsonCallBlocking(
+        path =
+          s"/api/me/visible-apis/${defaultApi.api.id.value}/${defaultApi.api.currentVersion.value}/plans",
+      )(using tenant, session)
+      planAuthorizedTeamCheck.status mustBe 200
+
+      val planJson = planAuthorizedTeamCheck.json.as[JsArray].value.find(json => (json \ "customName").as[String] == "MyPrivatePlan").get
+      (planJson \ "authorizedTeams").as[Seq[String]] must contain theSameElementsAs (Seq(teamConsumerId.value))
+
+    }
+  }
+
   "Anyone" can {
     "ask access for an api" in {
       setupEnvBlocking(


### PR DESCRIPTION
Deleting a key associated with a private plan with authorized teams had the infortunate side effet to remove key team from plan authorized team list

Fix #1144