### PR TITLE
feat(external-secrets): add external secrets in helm values for : s3,…

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -107,62 +107,87 @@ helm install daikoku ./helm/daikoku \
 ### Referencing an existing Secret (GitOps)
 
 The example above puts credentials in `values.yaml` (or on the command line),
-which is a problem as soon as that file is committed. Any `DAIKOKU_INIT_*` value
-can instead be injected from a Secret you own, through `daikoku.extraEnv`: leave
-the field empty under `initTenant`, and declare the variable with a `secretKeyRef`.
+which is a problem as soon as that file is committed. Create a standard
+Kubernetes `Secret` yourself (a YAML file applied with `kubectl apply`, Sealed
+Secrets, SOPS, …) and point the chart at it with `secrets.initTenant.existingSecret`.
+
+**1. Your Secret** (`daikoku-init-credentials.yaml` — keep this file out of git,
+or encrypt it):
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: daikoku-init-credentials
+  namespace: daikoku
+type: Opaque
+stringData:
+  otoroshi_client_id: admin-api-apikey-id
+  otoroshi_client_secret: your-otoroshi-secret
+  s3_secret: your-s3-secret-key
+  mailer_password: your-smtp-password
+```
+
+```sh
+kubectl apply -f daikoku-init-credentials.yaml
+```
+
+**2. Helm values** — tell the chart which Secret to read and how keys map to env
+vars:
+
+```yaml
+secrets:
+  initTenant:
+    existingSecret: daikoku-init-credentials
+    keys:
+      otoroshiClientId: otoroshi_client_id
+      otoroshiClientSecret: otoroshi_client_secret
+      s3Secret: s3_secret
+      mailerPassword: mailer_password
+```
+
+The key names under `keys` are the **key names inside your Secret** — they map to
+the `DAIKOKU_INIT_*` environment variables listed in the table below. Leave a
+mapping empty to keep the usual fallback for that credential (values.yaml →
+`*-init-tenant` Secret, or bundled Garage for S3).
+
+| `keys` field | Environment variable |
+|---|---|
+| `otoroshiClientId` | `DAIKOKU_INIT_OTOROSHI_CLIENT_ID` |
+| `otoroshiClientSecret` | `DAIKOKU_INIT_OTOROSHI_CLIENT_SECRET` |
+| `s3Secret` | `DAIKOKU_INIT_S3_SECRET` |
+| `mailerPassword` | `DAIKOKU_INIT_MAILER_PASSWORD` |
+
+Non-secret init-tenant settings (Otoroshi URL, S3 bucket, mailer host, …) stay
+under `daikoku.initTenant` in `values.yaml`. Mapped credentials are wired with
+`secretKeyRef` and never rendered into Helm-managed ConfigMaps or Secrets.
+
+The Secret must exist **before** the Daikoku pod starts. Editing its *content*
+does not restart the pods — use [Reloader](https://github.com/stakater/Reloader)
+or roll the Deployment yourself.
+
+#### Alternative: `daikoku.extraEnv`
+
+Any `DAIKOKU_INIT_*` value can also be injected through `daikoku.extraEnv` with
+a `secretKeyRef` — useful for credentials not covered by `secrets.initTenant`
+(mailer API keys, OAuth2 client secret, LDAP password, …):
 
 ```sh
 kubectl -n daikoku create secret generic daikoku-credentials \
-  --from-literal=otoroshi_client_id=admin-api-apikey-id \
-  --from-literal=otoroshi_client_secret=... \
-  --from-literal=s3_secret=... \
-  --from-literal=mailer_password=...
+  --from-literal=mailer_key=...
 ```
 
 ```yaml
 daikoku:
-  initTenant:
-    otoroshi:
-      url: https://otoroshi-api.example.com   # non-secret, stays here
-      host: otoroshi-api.example.com
-      # clientId / clientSecret: left empty, injected below
-    s3:
-      bucket: daikoku-assets
-      endpoint: https://s3.eu-west-1.amazonaws.com
-      access: AKIAIOSFODNN7EXAMPLE
-      # secret: left empty, injected below
-
   extraEnv:
-    - name: DAIKOKU_INIT_OTOROSHI_CLIENT_ID
+    - name: DAIKOKU_INIT_MAILER_KEY
       valueFrom:
-        secretKeyRef: { name: daikoku-credentials, key: otoroshi_client_id }
-    - name: DAIKOKU_INIT_OTOROSHI_CLIENT_SECRET
-      valueFrom:
-        secretKeyRef: { name: daikoku-credentials, key: otoroshi_client_secret }
-    - name: DAIKOKU_INIT_S3_SECRET
-      valueFrom:
-        secretKeyRef: { name: daikoku-credentials, key: s3_secret }
-    - name: DAIKOKU_INIT_MAILER_PASSWORD
-      valueFrom:
-        secretKeyRef: { name: daikoku-credentials, key: mailer_password }
+        secretKeyRef: { name: daikoku-credentials, key: mailer_key }
 ```
 
-The variable to declare is spelled out next to every secret-bearing field in
-[`values.yaml`](./helm/daikoku/values.yaml): `mailer.password` is marked
-`[DAIKOKU_INIT_MAILER_PASSWORD]`. The **key names inside your Secret are free**,
-since `secretKeyRef` maps them explicitly — which suits Secrets synced as-is from
-an external store.
-
-Leaving the matching field empty is what keeps the credential out of the cluster's
-plain-text objects: an empty value renders no key at all, so nothing lands in the
-ConfigMap, and the `*-init-tenant` Secret is not even created once no plain-text
-credential is left. `extraEnv` entries land in `env:`, which takes precedence over
-everything injected with `envFrom:`, so this works just as well for values the chart
-does not classify as secret, such as `DAIKOKU_INIT_OTOROSHI_CLIENT_ID`.
-
-The Secret must exist before the pod starts. Editing its *content* does not restart
-the pods — use [Reloader](https://github.com/stakater/Reloader) or roll the
-Deployment yourself.
+Leaving the matching field empty under `initTenant` keeps the credential out of
+plain-text Helm objects. `extraEnv` entries land in `env:`, which takes precedence
+over everything injected with `envFrom:`.
 
 ### Optional in-cluster dependencies
 

--- a/kubernetes/helm/daikoku/templates/_helpers.tpl
+++ b/kubernetes/helm/daikoku/templates/_helpers.tpl
@@ -177,6 +177,18 @@ Falls back to a user-provided existing Secret.
 {{- end }}
 
 {{/*
+External Secret holding init-tenant credentials (Otoroshi / S3 / mailer).
+Call with: (dict "ctx" $ "field" <keys field name, e.g. "otoroshiClientId">)
+Returns the key name in the external Secret when wired, empty otherwise.
+*/}}
+{{- define "daikoku.initTenant.externalKey" -}}
+{{- $its := .ctx.Values.secrets.initTenant -}}
+{{- if and $its.existingSecret (index $its.keys .field) -}}
+{{- index $its.keys .field -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Secret holding the PostgreSQL password.
 - embedded Postgres  -> the Secret this chart creates
 - external database  -> the user-provided existing Secret

--- a/kubernetes/helm/daikoku/templates/_init-tenant.tpl
+++ b/kubernetes/helm/daikoku/templates/_init-tenant.tpl
@@ -64,7 +64,11 @@ Both templates are called with the root context `.`.
   "DAIKOKU_INIT_TENANT_DEFAULT_MESSAGE" $it.defaultMessage
   "DAIKOKU_INIT_OTOROSHI_URL" $it.otoroshi.url
   "DAIKOKU_INIT_OTOROSHI_HOST" $it.otoroshi.host
-  "DAIKOKU_INIT_OTOROSHI_CLIENT_ID" $it.otoroshi.clientId
+-}}
+{{- if not (include "daikoku.initTenant.externalKey" (dict "ctx" . "field" "otoroshiClientId")) -}}
+{{- $_ := set $s "DAIKOKU_INIT_OTOROSHI_CLIENT_ID" $it.otoroshi.clientId -}}
+{{- end -}}
+{{- $s := merge $s (dict
   "DAIKOKU_INIT_S3_BUCKET" $s3Bucket
   "DAIKOKU_INIT_S3_ENDPOINT" $s3Endpoint
   "DAIKOKU_INIT_S3_REGION" $s3Region
@@ -137,21 +141,26 @@ Both templates are called with the root context `.`.
 {{- define "daikoku.initTenant.secretData" -}}
 {{- $it := .Values.daikoku.initTenant -}}
 {{- $sec := dict
-  "DAIKOKU_INIT_OTOROSHI_CLIENT_SECRET" $it.otoroshi.clientSecret
   "DAIKOKU_INIT_MAILER_KEY" $it.mailer.key
   "DAIKOKU_INIT_MAILER_API_KEY_PRIVATE" $it.mailer.apiKeyPrivate
-  "DAIKOKU_INIT_MAILER_PASSWORD" $it.mailer.password
   "DAIKOKU_INIT_MAILER_SENDGRID_APIKEY" $it.mailer.sendgridApiKey
   "DAIKOKU_INIT_AUTH_OAUTH2_CLIENT_SECRET" $it.auth.oauth2.clientSecret
   "DAIKOKU_INIT_AUDIT_ELASTIC_PASSWORD" $it.audit.elastic.password
 -}}
+{{- if not (include "daikoku.initTenant.externalKey" (dict "ctx" . "field" "otoroshiClientSecret")) -}}
+{{- $_ := set $sec "DAIKOKU_INIT_OTOROSHI_CLIENT_SECRET" $it.otoroshi.clientSecret -}}
+{{- end -}}
+{{- if not (include "daikoku.initTenant.externalKey" (dict "ctx" . "field" "mailerPassword")) -}}
+{{- $_ := set $sec "DAIKOKU_INIT_MAILER_PASSWORD" $it.mailer.password -}}
+{{- end -}}
 {{/* LDAP admin password is only user-provided when the bundled OpenLDAP is OFF
      (otherwise it comes from the OpenLDAP Secret, wired in the Deployment). */}}
 {{- if not .Values.openldap.enabled -}}
 {{- $_ := set $sec "DAIKOKU_INIT_AUTH_LDAP_ADMIN_PASSWORD" $it.auth.ldap.adminPassword -}}
 {{- end -}}
-{{/* S3 secret comes from the Garage-generated Secret when the bundle is on. */}}
-{{- if not .Values.garage.enabled -}}
+{{/* S3 secret comes from the Garage-generated Secret when the bundle is on,
+     or from secrets.initTenant.existingSecret when mapped there. */}}
+{{- if and (not .Values.garage.enabled) (not (include "daikoku.initTenant.externalKey" (dict "ctx" . "field" "s3Secret"))) -}}
 {{- $_ := set $sec "DAIKOKU_INIT_S3_SECRET" $it.s3.secret -}}
 {{- end -}}
 {{- range $k, $v := $sec }}

--- a/kubernetes/helm/daikoku/templates/deployment.yaml
+++ b/kubernetes/helm/daikoku/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         # Roll pods when configuration or provided secret values change.
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        checksum/secrets: {{ printf "%v|%v|%v|%v" .Values.secrets .Values.postgresql.auth.password .Values.externalDatabase.existingSecret (include "daikoku.initTenant.secretData" .) | sha256sum }}
+        checksum/secrets: {{ printf "%v|%v|%v|%v|%v" .Values.secrets .Values.postgresql.auth.password .Values.externalDatabase.existingSecret (include "daikoku.initTenant.secretData" .) .Values.secrets.initTenant | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -103,11 +103,43 @@ spec:
                 secretKeyRef:
                   name: {{ include "daikoku.garage.fullname" . }}-keys
                   key: accessKeyId
+            {{- end }}
+            {{- if include "daikoku.initTenant.externalKey" (dict "ctx" . "field" "s3Secret") }}
+            - name: DAIKOKU_INIT_S3_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.initTenant.existingSecret }}
+                  key: {{ include "daikoku.initTenant.externalKey" (dict "ctx" . "field" "s3Secret") }}
+            {{- else if .Values.garage.enabled }}
             - name: DAIKOKU_INIT_S3_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "daikoku.garage.fullname" . }}-keys
                   key: secretAccessKey
+            {{- end }}
+            {{- $its := .Values.secrets.initTenant -}}
+            {{- if $its.existingSecret }}
+            {{- with $its.keys.otoroshiClientId }}
+            - name: DAIKOKU_INIT_OTOROSHI_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $its.existingSecret }}
+                  key: {{ . }}
+            {{- end }}
+            {{- with $its.keys.otoroshiClientSecret }}
+            - name: DAIKOKU_INIT_OTOROSHI_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $its.existingSecret }}
+                  key: {{ . }}
+            {{- end }}
+            {{- with $its.keys.mailerPassword }}
+            - name: DAIKOKU_INIT_MAILER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $its.existingSecret }}
+                  key: {{ . }}
+            {{- end }}
             {{- end }}
             {{- if .Values.openldap.enabled }}
             # Bind password for the bundled OpenLDAP.

--- a/kubernetes/helm/daikoku/values.yaml
+++ b/kubernetes/helm/daikoku/values.yaml
@@ -58,12 +58,12 @@ daikoku:
   # Extra raw env vars for any other DAIKOKU_* setting, e.g.:
   #   - name: DAIKOKU_NOTIFICATIONS_PURGE_CRON
   #     value: "true"
-  # This is also how you feed a value from a Secret you own rather than writing it
-  # here in clear text — key names in the Secret are yours to choose. See
-  # "Referencing an existing Secret" in the README.
-  #   - name: DAIKOKU_INIT_MAILER_PASSWORD
+  # For init-tenant credentials (Otoroshi, S3, mailer password), prefer
+  # `secrets.initTenant.existingSecret` — see "Referencing an existing Secret" in
+  # the README. Use extraEnv for other secret-bearing DAIKOKU_INIT_* vars, e.g.:
+  #   - name: DAIKOKU_INIT_MAILER_KEY
   #     valueFrom:
-  #       secretKeyRef: { name: daikoku-credentials, key: mailer_password }
+  #       secretKeyRef: { name: daikoku-credentials, key: mailer_key }
   extraEnv: []
 
   # ===========================================================================
@@ -76,9 +76,9 @@ daikoku:
   #
   # Leave a value as "" (string) or null (bool/int) to skip it. Fields marked
   # [DAIKOKU_INIT_*] are rendered into a Kubernetes Secret under that key; the
-  # rest into a ConfigMap. To keep a credential out of this file entirely, leave it
-  # empty here and inject its variable from a Secret you own via `daikoku.extraEnv`
-  # — see "Referencing an existing Secret" in the README.
+  # rest into a ConfigMap. For Otoroshi client id/secret, S3 secret and mailer
+  # password, prefer `secrets.initTenant.existingSecret` so credentials never
+  # appear in Helm-managed objects — see the README.
   # ===========================================================================
   initTenant:
     # --- Identity & locale -----------------------------------------------------
@@ -104,8 +104,8 @@ daikoku:
     otoroshi:
       url: ""                      # e.g. https://otoroshi-api.your-domain.com
       host: ""                     # Host header Otoroshi expects, e.g. otoroshi-api.your-domain.com
-      clientId: ""                 # Otoroshi admin-api apikey client id. Empty -> "admin-api-apikey-id"
-      clientSecret: ""             # [DAIKOKU_INIT_OTOROSHI_CLIENT_SECRET] Empty -> "admin-api-apikey-secret"
+      clientId: ""                 # [DAIKOKU_INIT_OTOROSHI_CLIENT_ID] Empty -> app default. Prefer secrets.initTenant.keys.otoroshiClientId for GitOps.
+      clientSecret: ""             # [DAIKOKU_INIT_OTOROSHI_CLIENT_SECRET] Empty -> app default. Prefer secrets.initTenant.keys.otoroshiClientSecret for GitOps.
 
     # --- S3 bucket for asset storage -------------------------------------------
     # Set `bucket` to enable. For an in-cluster bucket, enable the bundled Garage
@@ -116,7 +116,7 @@ daikoku:
       endpoint: ""                 # S3 endpoint URL, e.g. https://s3.eu-west-1.amazonaws.com
       region: ""                   # e.g. eu-west-1. Empty -> "us-east-1"
       access: ""                   # access key id
-      secret: ""                   # [DAIKOKU_INIT_S3_SECRET] secret access key
+      secret: ""                   # [DAIKOKU_INIT_S3_SECRET] secret access key. Prefer secrets.initTenant.keys.s3Secret for GitOps.
       chunkSize: null              # multipart chunk size in bytes (int). null -> 8388608 (8MiB)
       v4auth: null                 # true (AWS SigV4, default) | false (legacy v2). null -> true
 
@@ -140,7 +140,7 @@ daikoku:
       host: ""                     # SMTP server host
       port: ""                     # SMTP port as a string, e.g. "25" | "587" | "465". Empty -> "25"
       username: ""                 # SMTP username (optional)
-      password: ""                 # [DAIKOKU_INIT_MAILER_PASSWORD] SMTP password (optional)
+      password: ""                 # [DAIKOKU_INIT_MAILER_PASSWORD] SMTP password (optional). Prefer secrets.initTenant.keys.mailerPassword for GitOps.
       # type=sendgrid:
       sendgridApiKey: ""           # [DAIKOKU_INIT_MAILER_SENDGRID_APIKEY] sendgrid api key
 
@@ -199,6 +199,14 @@ daikoku:
 # Secrets. Leave a value empty to auto-generate it on first install and KEEP it
 # stable across upgrades (rotating cypherSecret would make stored data unreadable).
 # Provide `existingSecret` to bring your own (must hold all DAIKOKU_* keys below).
+#
+# Init-tenant credentials (Otoroshi client id/secret, S3 secret, mailer password)
+# can likewise be supplied via `initTenant.existingSecret` pointing at a standard
+# Kubernetes Secret you create yourself (YAML file, Sealed Secrets, SOPS, …).
+# Set `existingSecret` to that Secret's name, then map each credential to the key
+# name it holds. Mapped values are wired with secretKeyRef and never rendered into
+# Helm-managed objects. Leave a key mapping empty to keep the usual fallback
+# (values.yaml -> *-init-tenant Secret, or bundled Garage for S3).
 # ---------------------------------------------------------------------------
 secrets:
   existingSecret: ""
@@ -207,6 +215,13 @@ secrets:
   cypherSecret: ""       # DAIKOKU_CYPHER_SECRET (data encryption)
   adminPassword: ""      # DAIKOKU_INIT_ADMIN_PASSWORD
   healthAccessKey: ""    # DAIKOKU_HEALTH_ACCESS_KEY (guards /health/details)
+  initTenant:
+    existingSecret: ""
+    keys:
+      otoroshiClientId: ""       # -> DAIKOKU_INIT_OTOROSHI_CLIENT_ID
+      otoroshiClientSecret: ""   # -> DAIKOKU_INIT_OTOROSHI_CLIENT_SECRET
+      s3Secret: ""               # -> DAIKOKU_INIT_S3_SECRET
+      mailerPassword: ""         # -> DAIKOKU_INIT_MAILER_PASSWORD
 
 # ---------------------------------------------------------------------------
 # Embedded PostgreSQL (StatefulSet + PVC). Set enabled:false to use externalDatabase.


### PR DESCRIPTION
## Summary
- Add `secrets.initTenant.existingSecret` to wire Otoroshi client id/secret, S3 secret and mailer password from a user-managed Kubernetes Secret
- Avoid rendering mapped credentials into Helm-managed ConfigMaps or Secrets
- Update kubernetes/README.md with a plain `kind: Secret` example

## Motivation
Credentials for Otoroshi, S3 and mailer should not live in `values.yaml`.

## Test plan
- Not tested

Code generated by IA to review ;p